### PR TITLE
feat: observe dynamic commit timeline updates

### DIFF
--- a/scripts/build-manifest.mjs
+++ b/scripts/build-manifest.mjs
@@ -1,6 +1,7 @@
 import fs from "fs/promises"
 
 const main = async () => {
+  await fs.mkdir("dist", { recursive: true })
   const manifest = await fs.readFile("manifest.json", "utf8")
   const { $schema, ...rest } = JSON.parse(manifest)
   await fs.writeFile("dist/manifest.json", JSON.stringify(rest, undefined, 2), { flag: "w+" })

--- a/src/contents/copy-commit-hash-in-pr.ts
+++ b/src/contents/copy-commit-hash-in-pr.ts
@@ -2,7 +2,8 @@ import { Logger, createLogger } from "../utils/logger";
 
 const BUTTON_ID = "gg-copy-hash-button";
 const PROCESSED_ATTR = "data-gg-processed";
-const TIMELINE_ITEM_SELECTOR = ".TimelineItem.TimelineItem--condensed";
+const TIMELINE_ITEM_SELECTOR = ".TimelineItem";
+const COMMIT_ITEM_HINT_SELECTOR = ".TimelineItem-badge .octicon-git-commit";
 const COMMIT_LINK_SELECTORS = [
   ".text-right.ml-1 a[href*=\"/commits/\"]",
   "a[href*=\"/commits/\"] > code",
@@ -34,9 +35,17 @@ const addCopyButton = (item: Element, hash: string) => {
   item.setAttribute(PROCESSED_ATTR, "true");
 };
 
+const isCommitItem = (item: Element): boolean => {
+  if (item.querySelector(COMMIT_ITEM_HINT_SELECTOR)) return true;
+  return COMMIT_LINK_SELECTORS.some((selector) =>
+    Boolean(item.querySelector(selector))
+  );
+};
+
 const processTimelineItems = (root: ParentNode) => {
   const items = Array.from(root.querySelectorAll(TIMELINE_ITEM_SELECTOR));
   for (const item of items) {
+    if (!isCommitItem(item)) continue;
     const hash = extractHash(item);
     if (!hash) continue;
     addCopyButton(item, hash);
@@ -56,6 +65,7 @@ const copyCommentHashInPR = (logger: Logger) => {
         if (!(added instanceof Element)) continue;
 
         if (added.matches(TIMELINE_ITEM_SELECTOR)) {
+          if (!isCommitItem(added)) continue;
           const hash = extractHash(added);
           if (hash) addCopyButton(added, hash);
         }

--- a/src/contents/copy-commit-hash-in-pr.ts
+++ b/src/contents/copy-commit-hash-in-pr.ts
@@ -1,30 +1,71 @@
 import { Logger, createLogger } from "../utils/logger";
 
 const BUTTON_ID = "gg-copy-hash-button";
+const PROCESSED_ATTR = "data-gg-processed";
+const TIMELINE_ITEM_SELECTOR = ".TimelineItem.TimelineItem--condensed";
+const COMMIT_LINK_SELECTORS = [
+  ".text-right.ml-1 a[href*=\"/commits/\"]",
+  "a[href*=\"/commits/\"] > code",
+  "a[href*=\"/commit/\"] > code",
+  "a.commit-link > tt"
+];
+
+const extractHash = (target: Element): string | null => {
+  for (const selector of COMMIT_LINK_SELECTORS) {
+    const node = target.querySelector(selector);
+    const text = node?.textContent?.trim();
+    if (!text) continue;
+
+    if (/^[0-9a-f]{7,40}$/i.test(text)) return text;
+  }
+  return null;
+};
+
+const addCopyButton = (item: Element, hash: string) => {
+  if (item.getAttribute(PROCESSED_ATTR) === "true") return;
+
+  const oldButtons = item.querySelectorAll(`:scope > button.${BUTTON_ID}`);
+  for (const b of Array.from(oldButtons.values())) {
+    item.removeChild(b);
+  }
+
+  const copyHashButton = createCopyHashButton(hash);
+  item.appendChild(copyHashButton);
+  item.setAttribute(PROCESSED_ATTR, "true");
+};
+
+const processTimelineItems = (root: ParentNode) => {
+  const items = Array.from(root.querySelectorAll(TIMELINE_ITEM_SELECTOR));
+  for (const item of items) {
+    const hash = extractHash(item);
+    if (!hash) continue;
+    addCopyButton(item, hash);
+  }
+};
 
 const copyCommentHashInPR = (logger: Logger) => {
   logger.messageOnLoaded();
 
-  const commits = document.querySelectorAll(
-    ".TimelineItem.TimelineItem--condensed"
-  );
-  for (const c of Array.from(commits.values())) {
-    const hashContainer = c.querySelector(".text-right.ml-1");
-    if (hashContainer === null) continue;
+  processTimelineItems(document);
 
-    const hash = hashContainer.querySelector("code > a")?.textContent;
-    if (typeof hash !== "string") continue;
+  const root =
+    document.querySelector(".js-discussion") ?? document.body;
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      for (const added of Array.from(mutation.addedNodes.values())) {
+        if (!(added instanceof Element)) continue;
 
-    // 既にコピーボタンがる場合は消す
-    const oldButtons = c.querySelectorAll(`:scope > button.${BUTTON_ID}`);
-    for (const b of oldButtons) {
-      c.removeChild(b);
+        if (added.matches(TIMELINE_ITEM_SELECTOR)) {
+          const hash = extractHash(added);
+          if (hash) addCopyButton(added, hash);
+        }
+
+        processTimelineItems(added);
+      }
     }
+  });
 
-    // コピーボタンを追加
-    const copyHashButton = createCopyHashButton(hash);
-    c.appendChild(copyHashButton);
-  }
+  observer.observe(root, { childList: true, subtree: true });
 };
 
 const createCopyHashButton = (hash: string): HTMLButtonElement => {


### PR DESCRIPTION
## Background

GitHub PR timelines update dynamically, so new commit items can appear after page load and miss the copy button.

## Changes

- Observe timeline mutations and process newly added commit items.
- Detect commit items without relying on the condensed class (use commit icon/link hints).
